### PR TITLE
删除部分多余注释，修复演示界面UI适配问题

### DIFF
--- a/MVI4Unity/Assets/Core/Utils/UtilGameObject.cs
+++ b/MVI4Unity/Assets/Core/Utils/UtilGameObject.cs
@@ -5,14 +5,6 @@ using UnityEngine;
 
 namespace MVI4Unity
 {
-    /// <summary>
-    /// @创建者: 江选辉
-    /// @创建日期: 2020/5/13 9:20:47
-    /// @功能描述: 用于对节点进行相关操作
-    /// @修改者：
-    /// @修改日期：
-    /// @修改描述：
-    /// </summary>
     public class UtilGameObject : SafeSingleton<UtilGameObject>
     {
         public void LogChildren (Transform node)

--- a/MVI4Unity/Assets/Resources/Windown01.prefab
+++ b/MVI4Unity/Assets/Resources/Windown01.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0.2393899, b: 1, a: 1}
+  m_Color: {r: 0.5191171, g: 0.60255736, b: 0.8679245, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -145,9 +145,9 @@ RectTransform:
   m_Father: {fileID: 8045326923596730931}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -240, y: -553}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -96}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4446294546056798448
@@ -482,7 +482,7 @@ GameObject:
   - component: {fileID: 8876995691750692038}
   - component: {fileID: 4802788474183991529}
   m_Layer: 5
-  m_Name: Add
+  m_Name: Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -641,7 +641,7 @@ GameObject:
   - component: {fileID: 2227811065634085231}
   - component: {fileID: 8518482012826383185}
   m_Layer: 5
-  m_Name: BtnAdd (1)
+  m_Name: BtnClose
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -663,9 +663,9 @@ RectTransform:
   m_Father: {fileID: 8045326923596730931}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 95, y: -553}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -196}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7528036887252163585
@@ -785,9 +785,9 @@ RectTransform:
   m_Father: {fileID: 8045326923596730931}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -71, y: -553}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -146}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8114466225031226874

--- a/MVI4Unity/Assets/Sample/Script/OpenViewMgr.cs
+++ b/MVI4Unity/Assets/Sample/Script/OpenViewMgr.cs
@@ -5,7 +5,7 @@ namespace MVI4Unity.Sample
     public class OpenViewMgr : SafeSingleton<OpenViewMgr>
     {
         /// <summary>
-        /// ÏÔÊ¾ÌáÊ¾
+        /// æ˜¾ç¤ºæç¤º
         /// </summary>
         /// <param name="content"></param>
         public void ShowTip (string content)
@@ -15,7 +15,7 @@ namespace MVI4Unity.Sample
         }
 
         /// <summary>
-        /// ÏÔÊ¾È·ÈÏ¿ò
+        /// æ˜¾ç¤ºç¡®è®¤æ¡†
         /// </summary>
         /// <param name="title"></param>
         /// <param name="content"></param>
@@ -32,7 +32,7 @@ namespace MVI4Unity.Sample
         }
 
         /// <summary>
-        /// ´ò¿ª´°¿Ú01
+        /// æ‰“å¼€çª—å£01
         /// </summary>
         public void OpenWindow01 ()
         {

--- a/MVI4Unity/Assets/Sample/Script/StartDemo.cs
+++ b/MVI4Unity/Assets/Sample/Script/StartDemo.cs
@@ -7,7 +7,6 @@ namespace MVI4Unity.Sample
         private void Awake ()
         {
             OpenViewMgr.Ins.ShowTip ("欢迎进入演示场景");
-            OpenViewMgr.Ins.OpenWindow01 ();
         }
     }
 }

--- a/MVI4Unity/Assets/Sample/Script/TipView.cs
+++ b/MVI4Unity/Assets/Sample/Script/TipView.cs
@@ -18,6 +18,7 @@ namespace MVI4Unity.Sample
     {
         [AWindowCom ("text")]
         public Text text;
+
     }
 
     public class TipViewState : AStateBase
@@ -39,6 +40,7 @@ namespace MVI4Unity.Sample
             await Task.Delay (1500);
             TipViewState state = new TipViewState ();
             state.shouldDestroy = true;
+            OpenViewMgr.Ins.OpenWindow01();
             return state;
         }
     }

--- a/MVI4Unity/Assets/Sample/Script/Window01.cs
+++ b/MVI4Unity/Assets/Sample/Script/Window01.cs
@@ -151,7 +151,6 @@ namespace MVI4Unity.Sample
                 {
                     //由Func01引起的变化
                 }
-                window.btn.GetComponent<RectTransform>()
                 window.btn.onClick.AddListener (() => { store.DisPatch (Reducer01.Reducer01MethodType.Func01 , default); });
                 window.btn2.onClick.AddListener (() => { store.DisPatch (Reducer01.Reducer01MethodType.Func02 , default); });
                 window.btnClose.onClick.AddListener (() => { store.DisPatch (ReducerCommonFunType.Close , default); });

--- a/MVI4Unity/Assets/Sample/Script/Window01.cs
+++ b/MVI4Unity/Assets/Sample/Script/Window01.cs
@@ -151,7 +151,7 @@ namespace MVI4Unity.Sample
                 {
                     //由Func01引起的变化
                 }
-
+                window.btn.GetComponent<RectTransform>()
                 window.btn.onClick.AddListener (() => { store.DisPatch (Reducer01.Reducer01MethodType.Func01 , default); });
                 window.btn2.onClick.AddListener (() => { store.DisPatch (Reducer01.Reducer01MethodType.Func02 , default); });
                 window.btnClose.onClick.AddListener (() => { store.DisPatch (ReducerCommonFunType.Close , default); });

--- a/MVI4Unity/UserSettings/Layouts/default-2022.dwlt
+++ b/MVI4Unity/UserSettings/Layouts/default-2022.dwlt
@@ -15,11 +15,11 @@ MonoBehaviour:
   m_PixelRect:
     serializedVersion: 2
     x: 0
-    y: 42.285717
-    width: 2194.286
-    height: 1144
+    y: 83.200005
+    width: 2048
+    height: 1068.8
   m_ShowMode: 4
-  m_Title: Project
+  m_Title: Hierarchy
   m_RootView: {fileID: 6}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -43,8 +43,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 30
-    width: 2194.2856
-    height: 1094
+    width: 2048
+    height: 1018.80005
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
@@ -64,10 +64,10 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 1749.7142
+    x: 1632.8
     y: 0
-    width: 444.5714
-    height: 1094
+    width: 415.19995
+    height: 1018.80005
   m_MinSize: {x: 276, y: 71}
   m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 14}
@@ -92,8 +92,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 433.14285
-    height: 661.1429
+    width: 404
+    height: 615.2
   m_MinSize: {x: 201, y: 221}
   m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 15}
@@ -117,9 +117,9 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 661.1429
-    width: 1749.7142
-    height: 432.85712
+    y: 615.2
+    width: 1632.8
+    height: 403.60004
   m_MinSize: {x: 231, y: 271}
   m_MaxSize: {x: 10001, y: 10021}
   m_ActualView: {fileID: 13}
@@ -148,8 +148,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 2194.2856
-    height: 1144
+    width: 2048
+    height: 1068.8
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
   m_UseTopView: 1
@@ -173,7 +173,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 2194.2856
+    width: 2048
     height: 30
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
@@ -194,8 +194,8 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 1124
-    width: 2194.2856
+    y: 1048.8
+    width: 2048
     height: 20
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
@@ -218,12 +218,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1749.7142
-    height: 1094
+    width: 1632.8
+    height: 1018.80005
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 50
+  controlID: 41
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -243,12 +243,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1749.7142
-    height: 661.1429
+    width: 1632.8
+    height: 615.2
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 41
+  controlID: 42
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -259,24 +259,24 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: SceneView
+  m_Name: GameView
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 433.14285
+    x: 404
     y: 0
-    width: 1316.5714
-    height: 661.1429
+    width: 1228.8
+    height: 615.2
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
-  m_ActualView: {fileID: 16}
+  m_ActualView: {fileID: 17}
   m_Panes:
   - {fileID: 16}
   - {fileID: 17}
   - {fileID: 12}
-  m_Selected: 0
-  m_LastSelected: 1
+  m_Selected: 1
+  m_LastSelected: 0
 --- !u!114 &12
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -293,7 +293,7 @@ MonoBehaviour:
   m_MaxSize: {x: 2048, y: 2048}
   m_TitleContent:
     m_Text: Asset Store
-    m_Image: {fileID: -4391848389275900105, guid: 0000000000000000d000000000000000,
+    m_Image: {fileID: -7444545952099596278, guid: 0000000000000000d000000000000000,
       type: 0}
     m_Tooltip: 
   m_Pos:
@@ -322,15 +322,15 @@ MonoBehaviour:
   m_MaxSize: {x: 10000, y: 10000}
   m_TitleContent:
     m_Text: Project
-    m_Image: {fileID: -2032128904892744680, guid: 0000000000000000d000000000000000,
+    m_Image: {fileID: -5179483145760003458, guid: 0000000000000000d000000000000000,
       type: 0}
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 733.7143
-    width: 1748.7142
-    height: 411.85712
+    y: 728.8
+    width: 1631.8
+    height: 382.60004
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -348,22 +348,22 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Core
+    - Assets/Resources
     m_Globs: []
     m_OriginalText: 
   m_ViewMode: 1
   m_StartGridSize: 16
   m_LastFolders:
-  - Assets/Core
+  - Assets/Resources
   m_LastFoldersGridSize: 16
-  m_LastProjectPath: C:\MVI4Unity\MVI4Unity
+  m_LastProjectPath: C:\Unity Projects\MVI4Unity\MVI4Unity
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: d0580000
-    m_LastClickedID: 22736
-    m_ExpandedIDs: 00000000ce580000
+    m_SelectedIDs: f0580000
+    m_LastClickedID: 22768
+    m_ExpandedIDs: 00000000d4580000f258000000ca9a3b
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -391,7 +391,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000be580000
+    m_ExpandedIDs: 00000000d4580000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -418,22 +418,22 @@ MonoBehaviour:
   m_ListAreaState:
     m_SelectedInstanceIDs: 
     m_LastClickedInstanceID: 0
-    m_HadKeyboardFocusLastEvent: 1
+    m_HadKeyboardFocusLastEvent: 0
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
-      m_Name: 
-      m_OriginalName: 
+      m_Name: Windown01
+      m_OriginalName: Windown01
       m_EditFieldRect:
         serializedVersion: 2
         x: 0
         y: 0
         width: 0
         height: 0
-      m_UserData: 0
+      m_UserData: 22744
       m_IsWaitingForDelay: 0
       m_IsRenaming: 0
-      m_OriginalEventType: 11
+      m_OriginalEventType: 0
       m_IsRenamingFilename: 1
       m_ClientGUIView: {fileID: 5}
     m_CreateAssetUtility:
@@ -463,15 +463,15 @@ MonoBehaviour:
   m_MaxSize: {x: 4000, y: 4000}
   m_TitleContent:
     m_Text: Inspector
-    m_Image: {fileID: 8356117983803934776, guid: 0000000000000000d000000000000000,
+    m_Image: {fileID: -440750813802333266, guid: 0000000000000000d000000000000000,
       type: 0}
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 1749.7144
-    y: 72.571434
-    width: 443.5714
-    height: 1073
+    x: 1632.8
+    y: 113.6
+    width: 414.19995
+    height: 997.80005
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -505,15 +505,15 @@ MonoBehaviour:
   m_MaxSize: {x: 4000, y: 4000}
   m_TitleContent:
     m_Text: Hierarchy
-    m_Image: {fileID: -9000905672528348964, guid: 0000000000000000d000000000000000,
+    m_Image: {fileID: -3734745235275155857, guid: 0000000000000000d000000000000000,
       type: 0}
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 72.571434
-    width: 432.14285
-    height: 640.1429
+    y: 113.6
+    width: 403
+    height: 594.2
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -521,9 +521,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: d0580000
+      m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 2afbffff
+      m_ExpandedIDs: 32c8ffff36c8fffff0d7fffff4d7ffffbee1ffffc2e1ffffb8e6ffffc2e6ffffc6e6ffff5ef0ffff68f0ffff6cf0ffff20fbffff2cfbffff32fbfffff4ffffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -539,7 +539,7 @@ MonoBehaviour:
         m_IsRenaming: 0
         m_OriginalEventType: 11
         m_IsRenamingFilename: 0
-        m_ClientGUIView: {fileID: 0}
+        m_ClientGUIView: {fileID: 4}
       m_SearchString: 
     m_ExpandedScenes: []
     m_CurrenRootInstanceID: 0
@@ -563,15 +563,15 @@ MonoBehaviour:
   m_MaxSize: {x: 4000, y: 4000}
   m_TitleContent:
     m_Text: Scene
-    m_Image: {fileID: -131512000283675692, guid: 0000000000000000d000000000000000,
+    m_Image: {fileID: 8634526014445323508, guid: 0000000000000000d000000000000000,
       type: 0}
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 433.14288
-    y: 72.571434
-    width: 1314.5714
-    height: 640.1429
+    x: 404
+    y: 113.6
+    width: 1226.8
+    height: 594.2
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -581,8 +581,8 @@ MonoBehaviour:
       floating: 0
       collapsed: 0
       displayed: 1
-      snapOffset: {x: 0, y: 0}
-      snapOffsetDelta: {x: -173.71423, y: -26.285706}
+      snapOffset: {x: -175.19995, y: -25.599976}
+      snapOffsetDelta: {x: 0, y: 0}
       snapCorner: 3
       id: Tool Settings
       index: 0
@@ -603,7 +603,7 @@ MonoBehaviour:
       floating: 0
       collapsed: 0
       displayed: 1
-      snapOffset: {x: 0, y: 0}
+      snapOffset: {x: 0, y: 24.8}
       snapOffsetDelta: {x: 0, y: 0}
       snapCorner: 0
       id: unity-scene-view-toolbar
@@ -625,7 +625,7 @@ MonoBehaviour:
       floating: 0
       collapsed: 0
       displayed: 1
-      snapOffset: {x: 0, y: 0}
+      snapOffset: {x: 0, y: 24.8}
       snapOffsetDelta: {x: 0, y: 0}
       snapCorner: 0
       id: unity-transform-toolbar
@@ -806,9 +806,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: -7.8553452, y: 4.635517, z: -0.08519437}
+    m_Target: {x: 1107.3551, y: 846.7417, z: 7.1712394}
     speed: 2
-    m_Value: {x: -7.8553452, y: 4.635517, z: -0.08519437}
+    m_Value: {x: 1107.3551, y: 846.7417, z: 7.1712394}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -858,9 +858,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 18.519447
+    m_Target: 1234.452
     speed: 2
-    m_Value: 18.519447
+    m_Value: 1234.452
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -901,15 +901,15 @@ MonoBehaviour:
   m_MaxSize: {x: 4000, y: 4000}
   m_TitleContent:
     m_Text: Game
-    m_Image: {fileID: 257045534191678443, guid: 0000000000000000d000000000000000,
+    m_Image: {fileID: 4621777727084837110, guid: 0000000000000000d000000000000000,
       type: 0}
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 433.14288
-    y: 72.571434
-    width: 1314.5714
-    height: 640.1429
+    x: 404
+    y: 113.6
+    width: 1226.8
+    height: 594.2
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -920,7 +920,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 640, y: 1136}
+  m_TargetSize: {x: 3840, y: 2160}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -934,16 +934,16 @@ MonoBehaviour:
   m_PlayFocused: 0
   m_Gizmos: 0
   m_Stats: 0
-  m_SelectedSizes: 07000000000000000000000000000000000000000000000000000000000000000000000000000000
+  m_SelectedSizes: 06000000000000000000000000000000000000000000000000000000000000000000000000000000
   m_ZoomArea:
     m_HRangeLocked: 0
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -182.85715
-    m_HBaseRangeMax: 182.85715
-    m_VBaseRangeMin: -324.57144
-    m_VBaseRangeMax: 324.57144
+    m_HBaseRangeMin: -1536
+    m_HBaseRangeMax: 1536
+    m_VBaseRangeMin: -864
+    m_VBaseRangeMax: 864
     m_HAllowExceedBaseRangeMin: 1
     m_HAllowExceedBaseRangeMax: 1
     m_VAllowExceedBaseRangeMin: 1
@@ -952,7 +952,7 @@ MonoBehaviour:
     m_HSlider: 0
     m_VSlider: 0
     m_IgnoreScrollWheelUntilClicked: 0
-    m_EnableMouseInput: 0
+    m_EnableMouseInput: 1
     m_EnableSliderZoomHorizontal: 0
     m_EnableSliderZoomVertical: 0
     m_UniformScale: 1
@@ -961,23 +961,23 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 1314.5714
-      height: 619.1429
-    m_Scale: {x: 0.95378524, y: 0.95378524}
-    m_Translation: {x: 657.2857, y: 309.57144}
+      width: 1226.8
+      height: 573.2
+    m_Scale: {x: 0.33171296, y: 0.33171296}
+    m_Translation: {x: 613.4, y: 286.6}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -689.13385
-      y: -324.57144
-      width: 1378.2677
-      height: 649.1429
+      x: -1849.1892
+      y: -864
+      width: 3698.3784
+      height: 1728
     m_MinimalGUI: 1
-  m_defaultScale: 0.95378524
-  m_LastWindowPixelSize: {x: 2300.5, y: 1120.25}
+  m_defaultScale: 0.33171296
+  m_LastWindowPixelSize: {x: 1533.5, y: 742.75}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 00000000000000000000
@@ -1001,15 +1001,15 @@ MonoBehaviour:
   m_MaxSize: {x: 4000, y: 4000}
   m_TitleContent:
     m_Text: Console
-    m_Image: {fileID: -3303252850963283158, guid: 0000000000000000d000000000000000,
+    m_Image: {fileID: -4950941429401207979, guid: 0000000000000000d000000000000000,
       type: 0}
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 733.7143
-    width: 1748.7142
-    height: 411.85712
+    y: 728.8
+    width: 1631.8
+    height: 382.60004
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default


### PR DESCRIPTION
发现有部分注释存在隐私信息，帮您进行了删除；
同时发现演示项目中UI没有做显示适配，帮您进行了完善：修改了window01中按钮的布局与对齐方式，确保所有UI可以完整显示并且不冲突。
另外将window01的激活放到了提示界面的销毁结束前，看起来更舒适。